### PR TITLE
Fixed instructions (tested working on macOS Sierra 10.12.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ Installation and usage:
 - [Download app](https://raw.githubusercontent.com/sozercan/OpenInCode/master/OpenInCode.app.zip)
 (if using [VSCode Insiders](https://code.visualstudio.com/insiders), download [this](https://github.com/sozercan/OpenInCode/raw/master/Open%20in%20Code%20-%20Insiders.app.zip) instead)
 - Move Open in Code.app to /Applications
+- Go to /Applications
 - While holding Command key, drag Open in Code.app to Finder toolbar
+- Right-click Open in Code.app and click Open. When the security dialog prompt appears, click Open.
+- Once Visual Studio Code new window is opened, close it.
 - Navigate to a folder you want to open with Visual Studio Code
 - Click on the toolbar icon
-- For first time only, say 'yes' to security dialog prompt
 - Folder will open with Visual Studio Code
 
 ![](http://i.imgur.com/F5ZrCmS.gif)


### PR DESCRIPTION
On macOS Sierra the security dialog prompt doesn't have, with the default settings, the "Allow/Open" button. Instead, it appears when right-clicking the .app and choosing Open in the popup menu.